### PR TITLE
Using UnstructuredRemittanceIdentifier in MD5FingerPrint

### DIFF
--- a/src/TransferInitiatorDetails.php
+++ b/src/TransferInitiatorDetails.php
@@ -153,8 +153,10 @@ class TransferInitiatorDetails
 
     public function GetMD5Fingerprint()
     {
+        $remittanceIdentifier = $this->UnstructuredRemittanceIdentifier ?: $this->RemittanceIdentifier;
+
         $input = $this->Secret . $this->Date . $this->ReferenceIdentifier . $this->BeneficiaryAccountIdentifier
-                . $this->RemittanceIdentifier . $this->InstructedAmount . $this->AmountCurrencyIdentifier
+                . $remittanceIdentifier . $this->InstructedAmount . $this->AmountCurrencyIdentifier
                 . $this->UserId;
 
         return md5($input);

--- a/tests/unit/at/externet/eps_bank_transfer/TransferInitiatorDetailsTest.php
+++ b/tests/unit/at/externet/eps_bank_transfer/TransferInitiatorDetailsTest.php
@@ -85,4 +85,52 @@ class TransferInitiatorDetailsTest extends BaseTest
         XmlValidator::ValidateEpsProtocol($actual);
         $this->assertContains('UnstructuredRemittanceIdentifier>Foo is not Bar', $actual);
     }
+
+    public function testMD5FingerprintIsCalculatedCorrectly()
+    {
+        $transferMsgDetails = new TransferMsgDetails("http://10.18.70.8:7001/vendorconfirmation", "http://10.18.70.8:7001/transactionok?danke.asp", "http://10.18.70.8:7001/transactionnok?fehler.asp");
+        $transferMsgDetails->TargetWindowNok = $transferMsgDetails->TargetWindowOk = 'Mustershop';
+
+        $secret = 'topSecret';
+        $date = '2007-03-16';
+        $referenceIdentifier = '1234567890ABCDEFG';
+        $beneficiaryAccountIdentifier = 'AT611904300234573201';
+        $instructedAmount = 15000;
+        $amountCurrencyIdentifier = 'EUR';
+        $userId = 'AKLJS231534';
+        $remittanceIdentifier = "remittanceIdentifier";
+
+        $data = new TransferInitiatorDetails($userId, $secret, 'GAWIATW1XXX', 'Max Mustermann', $beneficiaryAccountIdentifier, $referenceIdentifier, $instructedAmount, $transferMsgDetails, $date);
+        $data->RemittanceIdentifier = $remittanceIdentifier;
+
+        $actual = $data->GetMD5Fingerprint();
+
+        $string = $secret . $date . $referenceIdentifier . $beneficiaryAccountIdentifier . $remittanceIdentifier . FormatMonetaryXsdDecimal($instructedAmount) . $amountCurrencyIdentifier . $userId;
+        $expected = md5($string);
+        $this->assertEquals($expected, $actual, 'Expected MD5 Fingerprint to be equal');
+    }
+
+    public function testMD5FingerprintIsCalculatedCorrectlyWithAnUnstructuredRemittanceIdentifier()
+    {
+        $transferMsgDetails = new TransferMsgDetails("http://10.18.70.8:7001/vendorconfirmation", "http://10.18.70.8:7001/transactionok?danke.asp", "http://10.18.70.8:7001/transactionnok?fehler.asp");
+        $transferMsgDetails->TargetWindowNok = $transferMsgDetails->TargetWindowOk = 'Mustershop';
+
+        $secret = 'topSecret';
+        $date = '2007-03-16';
+        $referenceIdentifier = '1234567890ABCDEFG';
+        $beneficiaryAccountIdentifier = 'AT611904300234573201';
+        $instructedAmount = 15000;
+        $amountCurrencyIdentifier = 'EUR';
+        $userId = 'AKLJS231534';
+        $unstructuredRemittanceIdentifier = 'unstructuredRemittanceIdentifier';
+
+        $data = new TransferInitiatorDetails($userId, $secret, 'GAWIATW1XXX', 'Max Mustermann', $beneficiaryAccountIdentifier, $referenceIdentifier, $instructedAmount, $transferMsgDetails, $date);
+        $data->UnstructuredRemittanceIdentifier = $unstructuredRemittanceIdentifier;
+
+        $actual = $data->GetMD5Fingerprint();
+
+        $string = $secret . $date . $referenceIdentifier . $beneficiaryAccountIdentifier . $unstructuredRemittanceIdentifier . FormatMonetaryXsdDecimal($instructedAmount) . $amountCurrencyIdentifier . $userId;
+        $expected = md5($string);
+        $this->assertEquals($expected, $actual, 'Expected MD5 Fingerprint to be equal');
+    }
 }


### PR DESCRIPTION
The EPS API requires the use of the unstructured remittance identifier if it is specified in the XML. The Pflichtenheft is ambiguous in that point but may be fixed in the future. This fact was explained to me by their support team.

Without this patch no transactions with an UnstructuredRemittanceIdentifier can be made as it will return a fingerprint issue (and finally lock your account).