### PR TITLE
Update tested PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: php
 php:
+  - 7.1
+  - 7.0
   - 5.6
   - 5.5
   - 5.4
   - 5.3
   - hhvm
+  - nightly
 before_script:
   - composer install --dev
   - composer update satooshi/php-coveralls --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: php
+sudo: required
+dist: trusty
+group: edge
 php:
   - 7.1
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,15 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
-  - hhvm-3.6
-  - hhvm
+  - 5.3  
   - nightly
 matrix:
+  include:
+    - dist: trusty
+      php: hhvm
+      sudo: required
   allow_failures:
     - php: nightly
-    - php: hhvm
 before_script:
   - composer install --dev
   - composer update satooshi/php-coveralls --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: php
-sudo: required
-dist: trusty
-group: edge
 php:
   - 7.1
   - 7.0
@@ -9,11 +6,13 @@ php:
   - 5.5
   - 5.4
   - 5.3
+  - hhvm-3.6
   - hhvm
   - nightly
 matrix:
   allow_failures:
     - php: nightly
+    - php: hhvm
 before_script:
   - composer install --dev
   - composer update satooshi/php-coveralls --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ php:
   - 5.3
   - hhvm
   - nightly
+matrix:
+  allow_failures:
+    - php: nightly
 before_script:
   - composer install --dev
   - composer update satooshi/php-coveralls --dev


### PR DESCRIPTION
Nightly fails because of the old PHPUnit version which is incompatible to a change in php's master but upgrading PHPUnit also means dropping support for some of the eol'ed php versions.